### PR TITLE
StableType and AsFixedSizedBytes trait implemented for Subaccount

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.showUnlinkedFileNotification": false
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num-bigint = "0.4.3"
 sha2 = "0.10.6"
 zwohash = "0.1.2"
 ic-stable-memory-derive = "0.4.2"
+ic-ledger-types = "0.4.2"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/encoding/fixed_size.rs
+++ b/src/encoding/fixed_size.rs
@@ -13,6 +13,7 @@
 
 use candid::{Int, Nat, Principal};
 use num_bigint::{BigInt, BigUint, Sign};
+use ic_ledger_types::Subaccount;
 
 /// Allows fast and space-efficient fixed size data encoding.
 ///
@@ -458,6 +459,25 @@ impl AsFixedSizeBytes for Principal {
         let len = buf[0] as usize;
 
         Principal::from_slice(&buf[1..(1 + len)])
+    }
+}
+
+impl AsFixedSizeBytes for Subaccount{
+    const SIZE: usize = 32;
+    type Buf = [u8; Self::SIZE];
+
+    fn as_fixed_size_bytes(&self, buf: &mut [u8]) {
+        let slice = self.0.as_slice();
+
+        buf[0] = slice.len() as u8;
+        buf[1..(1 + slice.len())].copy_from_slice(slice)
+    }
+
+    fn from_fixed_size_bytes(buf: &[u8]) -> Self {
+        let len = buf[0] as usize;
+        let mut subaccount: [u8; 32] = [0; 32];
+        subaccount.copy_from_slice(&buf[1..(1 + len)]);
+        Subaccount(subaccount)
     }
 }
 

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -3,6 +3,7 @@
 use candid::{Int, Nat, Principal};
 use serde_bytes::ByteBuf;
 use std::collections::{BTreeSet, HashSet};
+use ic_ledger_types::Subaccount;
 
 /// [SBox] smart-pointer that allows storing dynamically-sized data to stable memory
 pub mod s_box;
@@ -397,3 +398,4 @@ impl StableType for BTreeSet<Principal> {}
 impl StableType for BTreeSet<Nat> {}
 impl StableType for BTreeSet<Int> {}
 impl StableType for BTreeSet<ByteBuf> {}
+impl StableType for Subaccount{}


### PR DESCRIPTION
Subaccount is a part of ic-ledger-types. Subaccount helps in creating different address for a single canister.